### PR TITLE
fix: review phase 2 (NaN, strip, zero-byte, e2e race)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,14 @@ jobs:
       JWT_ACCESS_TOKEN_EXPIRES_MINUTES: "60"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.13"
 

--- a/apps/api/src/api/main.py
+++ b/apps/api/src/api/main.py
@@ -1,5 +1,6 @@
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -14,6 +15,7 @@ from api.routers.meetings import router as meetings_router
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    Path(get_settings().storage_root).mkdir(parents=True, exist_ok=True)
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     yield

--- a/apps/api/src/api/meeting_files/commands.py
+++ b/apps/api/src/api/meeting_files/commands.py
@@ -37,7 +37,7 @@ class UploadMeetingFileHandler:
 
         # Validation: extension and content_type
         settings = get_settings()
-        original_filename = command.upload_file.filename or ""
+        original_filename = (command.upload_file.filename or "").strip()
         ext = Path(original_filename).suffix.lower()
 
         if not original_filename or ext not in settings.allowed_extensions:
@@ -58,6 +58,10 @@ class UploadMeetingFileHandler:
         relative_path, stored_filename, size = await self._storage.save(
             command.upload_file, command.meeting_id
         )
+
+        if size == 0:
+            await self._storage.delete(relative_path)
+            raise FileTypeNotAllowedError("Пустой файл не разрешен")
 
         meeting_file = MeetingFile(
             meeting_id=command.meeting_id,

--- a/apps/web/e2e/meeting-files.spec.ts
+++ b/apps/web/e2e/meeting-files.spec.ts
@@ -36,8 +36,7 @@ async function loginViaStorage(
   token: string,
   email: string,
 ) {
-  await page.goto("/");
-  await page.evaluate(
+  await page.addInitScript(
     ({ t, e }: { t: string; e: string }) => {
       localStorage.setItem("access_token", t);
       localStorage.setItem("user_email", e);

--- a/apps/web/src/app/meetings/[id]/page.tsx
+++ b/apps/web/src/app/meetings/[id]/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+/* eslint-disable react-hooks/set-state-in-effect */
+
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { Alert, Button, Card, Spinner } from "@heroui/react";
@@ -38,9 +40,10 @@ const ALLOWED_EXTS = new Set([".mp4", ".mov", ".wav", ".mp3", ".pdf", ".docx"]);
 const MAX_SIZE = 100 * 1024 * 1024;
 
 export default function MeetingPage() {
-  const params = useParams<{ id: string }>();
+  const params = useParams<{ id: string | string[] }>();
   const router = useRouter();
-  const meetingId = Number(params.id);
+  const rawId = Array.isArray(params.id) ? params.id[0] : params.id;
+  const meetingId = Number(rawId);
 
   const [session, setSession] = useState<Session | null | undefined>(undefined);
   const [meeting, setMeeting] = useState<Meeting | null>(null);
@@ -63,12 +66,19 @@ export default function MeetingPage() {
       router.replace("/login");
       return;
     }
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setSession(current);
   }, [router]);
 
   useEffect(() => {
-    if (!session || !Number.isFinite(meetingId)) return;
+    if (!session) return;
+
+    if (!Number.isFinite(meetingId)) {
+      setMeetingError("Встреча не найдена");
+      setFilesError("Встреча не найдена");
+      setIsLoadingMeeting(false);
+      setIsLoadingFiles(false);
+      return;
+    }
 
     let cancelled = false;
 
@@ -81,6 +91,8 @@ export default function MeetingPage() {
         if (error instanceof ApiError && error.status === 401) {
           clearSession();
           router.replace("/login");
+          setIsLoadingMeeting(false);
+          setIsLoadingFiles(false);
           return;
         }
         if (error instanceof ApiError && error.status === 404) {
@@ -106,6 +118,8 @@ export default function MeetingPage() {
         if (error instanceof ApiError && error.status === 401) {
           clearSession();
           router.replace("/login");
+          setIsLoadingMeeting(false);
+          setIsLoadingFiles(false);
           return;
         }
         if (error instanceof ApiError && error.status === 404) {


### PR DESCRIPTION
Follow-up к #19 (уже вмержен в 5372929).

Фиксы по ревью:

- web: `meetings/[id]/page.tsx` — NaN/array param → 404 с снятием лоадеров, 401 сброс лоадеров, file-level eslint-disable, addInitScript в e2e
- api: `commands.py` — filename `.strip()`, zero-byte guard 400, `main.py` mkdir storage в lifespan
- e2e: `meeting-files.spec.ts` — loginViaStorage via addInitScript

Проверки: lint/typecheck passed, playwright 4 passed, pytest 46 passed (test DB).